### PR TITLE
Fix debian build for 1.5.4

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -11,8 +11,8 @@ include /usr/share/cdbs/1/rules/autoreconf.mk
 DEB_CONFIGURE_EXTRA_FLAGS := --sbindir=/usr/bin --with-udev-rules PYINSTALL_FLAGS=--install-layout=deb
 DEB_MAKE_INSTALL_TARGET := install DESTDIR=$(DEB_DESTDIR) udevrulesdir=/lib/udev/rules.d udevhelperdir=/lib/udev
 
-binary-install/python-cupshelpers::
-	dh_python2 -ppython-cupshelpers
+binary-install/python3-cupshelpers::
+	dh_python3 -ppython3-cupshelpers
 
 # Generate the service file before the build so we substitute the
 # correct path to the udev helper.

--- a/debian/rules
+++ b/debian/rules
@@ -8,7 +8,7 @@ include /usr/share/cdbs/1/class/gnome.mk
 include /usr/share/cdbs/1/rules/simple-patchsys.mk
 include /usr/share/cdbs/1/rules/autoreconf.mk
 
-DEB_CONFIGURE_EXTRA_FLAGS := --sbindir=/usr/bin --with-udev-rules
+DEB_CONFIGURE_EXTRA_FLAGS := --sbindir=/usr/bin --with-udev-rules PYINSTALL_FLAGS=--install-layout=deb
 DEB_MAKE_INSTALL_TARGET := install DESTDIR=$(DEB_DESTDIR) udevrulesdir=/lib/udev/rules.d udevhelperdir=/lib/udev
 
 binary-install/python-cupshelpers::


### PR DESCRIPTION
Pass in --install-layout=deb and use dh_python3 for the python3-cupshelpers package.

[endlessm/eos-shell#4445]
