### PR TITLE
openprinting: Use 'i386' as architecture when running in 32bit mode

### DIFF
--- a/cupshelpers/openprinting.py
+++ b/cupshelpers/openprinting.py
@@ -376,11 +376,19 @@ class OpenPrinting:
         if isinstance(model, Device):
             model = model.id
 
+        architecture = platform.machine()
+
+        # On Intel, we could be running a 32bit user space with a 64bit kernel, in
+        # which case platform.machine() will return x86_64, leading to downloading
+        # the wrong printer driver, so we make sure we ask for i386 in that case.
+        if architecture == 'x86_64' and platform.architecture()[0] == '32bit':
+            architecture = 'i386'
+
         params = { 'type': 'drivers',
                    'moreinfo': '1',
                    'showprinterid': '1',
                    'onlynewestdriverpackages': '1',
-                   'architectures': platform.machine(),
+                   'architectures': architecture,
                    'noobsoletes': '1',
                    'onlyfree': str (self.onlyfree),
                    'onlymanufacturer': str (self.onlymanufacturer),

--- a/ui/NewPrinterWindow.ui
+++ b/ui/NewPrinterWindow.ui
@@ -6,8 +6,8 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">New Printer</property>
     <property name="window_position">center-on-parent</property>
-    <property name="default_width">720</property>
-    <property name="default_height">480</property>
+    <property name="default_width">800</property>
+    <property name="default_height">600</property>
     <signal name="delete-event" handler="on_NPCancel" swapped="no"/>
     <child>
       <object class="GtkBox" id="vbox9">


### PR DESCRIPTION
Do this to try to query for the right driver from Openprinting, regardless
of the kernel and user-space not matching the effective architecture, falling
back to Python's platform.machine() in case of error.

Additionally, I sneaked an additional commit in to fix the too-small default
resolution set when working on T6312, to improve a bit the download dialog.

https://phabricator.endlessm.com/T10803
