### PR TITLE
Always query openprinting for drivers if connected to Internet

### DIFF
--- a/cupshelpers/ppds.py
+++ b/cupshelpers/ppds.py
@@ -403,6 +403,61 @@ class PPDs:
             if not makemodel.startswith ("Generic "):
                 self.ppds['raw']['ppd-make-and-model'] = "Generic " + makemodel
 
+    def _availableFromRemoteSources(self, ppdname):
+        # We know a PPD is available to be installed from remote sources if either:
+        #  1. It has been installed by our automatic installer (eos-config-printer)
+        #  2. It contains the 'OpenPrinting' string in the PPD's name
+        #  3. It's a vendor-specific & LSB-compliant driver that we pre-install
+        #     (so far this only applies to Epson and Canon drivers)
+        regexps = [
+            '.*eos-config-printer.*ppd.*',
+            '.*OpenPrinting.*ppd.*',
+            'lsb/.*epson-inkjet-printer.*ppd.*',
+            'lsb/.*canon.*ppd.*'
+        ]
+
+        _debugprint("Checking whether PPD %s is available from remote sources..." % (ppdname))
+        for regexp in regexps:
+            _debugprint("Checking PPD name against regular expression %s..." % (regexp))
+            if re.match(regexp, ppdname) != None:
+                _debugprint("Regular expression '%s' MATCHED for %s" % (regexp, ppdname))
+                return True
+
+        # The PPD file is only available from local sources (i.e. pre-installed packages)
+        _debugprint("No regular expression matched PPD")
+        return False
+
+    def needsQueryingRemoteSources(self, ppdnamelist, fit):
+        """
+        Determines if it would be needed to query remote sources for additional
+        drivers based on a list of PPDs and how good of a fit each of them are.
+
+        @param ppdnamelist: PPD names
+        @type ppdnamelist: string list
+        @param fit: Driver fit string for each PPD name
+        @type fit: dict of PPD name:fit
+        @returns: True if remote sources should be queried, or False otherwise
+        """
+        # We don't want to spawn a remote query if at least one of the PPDs
+        # that are locally available already comes from remote sources.
+        _debugprint("Checking whether we need to query remote sources for drivers "
+                    "based on current list of PPDs: %s..." % (repr(ppdnamelist)))
+        for ppdname in ppdnamelist:
+            # Disregard PPD if not a good enough fit, as we can't trust it anyway
+            if self.getStatusFromFit(fit[ppdname]) != self.STATUS_SUCCESS:
+                _debugprint("PPD %s is not a good enough fit, disregarded" % (ppdname))
+                continue
+
+            # At least one of the good enough PPDs we already have is known to be
+            # available from remote sources: no need query again.
+            if self._availableFromRemoteSources(ppdname):
+                _debugprint("PPD %s is available from remote sources: no need to query" % (ppdname))
+                return False
+
+        # No match, we need to query remote sources
+        _debugprint("No local PPD file from list available from remote sources: needs querying")
+        return True
+
     def getMakes (self):
         """
 	@returns: a list of strings representing makes, sorted according

--- a/scp-dbus-service.py
+++ b/scp-dbus-service.py
@@ -199,10 +199,9 @@ class GetBestDriversRequest:
                                                           devid=id_dict,
                                                           fit=fit)
             ppdname = ppdnamelist[0]
-            status = fit[ppdname]
 
             try:
-                if status != "exact" and not self.download_tried:
+                if not self.download_tried:
                     self.download_tried = True
                     self.dialog = newprinter.NewPrinterGUI()
                     self.dialog.NewPrinterWindow.set_modal (False)

--- a/scp-dbus-service.py
+++ b/scp-dbus-service.py
@@ -198,10 +198,10 @@ class GetBestDriversRequest:
                                                           self.installed_files,
                                                           devid=id_dict,
                                                           fit=fit)
-            ppdname = ppdnamelist[0]
+            needs_querying = ppds.needsQueryingRemoteSources(ppdnamelist, fit)
 
             try:
-                if not self.download_tried:
+                if needs_querying and not self.download_tried:
                     self.download_tried = True
                     self.dialog = newprinter.NewPrinterGUI()
                     self.dialog.NewPrinterWindow.set_modal (False)

--- a/xml/preferreddrivers.xml
+++ b/xml/preferreddrivers.xml
@@ -182,9 +182,14 @@
       </fit>
     </drivertype>
 
-    <!-- If two exact drivers are available where one is coming as recommended -->
-    <!-- from openprinting we want to select that one unless an exact-cmd one  -->
+    <!-- If two 'exact' drivers are available where one has been installed via -->
+    <!-- eos-config-printer we want to select that one unless an exact-cmd one -->
     <!-- is available. So, define this category to use in the preferred order. -->
+    <drivertype name="eos-config-printer-installed">
+      <ppdname match=".*eos-config-printer.*ppd.*"/>
+    </drivertype>
+
+    <!-- Likewise, for other drivers coming from OpenPrinting.org -->
     <drivertype name="openprinting-recommended">
       <ppdname match=".*OpenPrinting.*ppd.*"/>
     </drivertype>
@@ -291,6 +296,7 @@
       <!-- For all printers which the available driver should take
            priority over others with 'exact' fit (but not 'exact-cmd') -->
       <drivers>
+	<drivertype>eos-config-printer-installed</drivertype>
 	<drivertype>openprinting-recommended</drivertype>
 	<drivertype>epson-recommended</drivertype>
 	<drivertype>canon-recommended</drivertype>

--- a/xml/preferreddrivers.xml
+++ b/xml/preferreddrivers.xml
@@ -182,6 +182,23 @@
       </fit>
     </drivertype>
 
+    <!-- If two exact drivers are available where one is coming as recommended -->
+    <!-- from openprinting we want to select that one unless an exact-cmd one  -->
+    <!-- is available. So, define this category to use in the preferred order. -->
+    <drivertype name="openprinting-recommended">
+      <ppdname match=".*OpenPrinting.*ppd.*"/>
+    </drivertype>
+
+    <!-- Likewise, for drivers directly provided by Epson. -->
+    <drivertype name="epson-recommended">
+      <ppdname match="lsb/.*epson-inkjet-printer.*ppd.*"/>
+    </drivertype>
+
+    <!-- Likewise, for drivers directly provided by Canon. -->
+    <drivertype name="canon-recommended">
+      <ppdname match="lsb/.*canon.*ppd.*"/>
+    </drivertype>
+
     <!-- Catch-all -->
     <drivertype name="manufacturer"/>
   </drivertypes>
@@ -264,9 +281,25 @@
     </printer>
 
     <printer>
-      <!-- For all printers -->
+      <!-- For all printers with the strongest possible fit -->
       <drivers>
 	<drivertype>manufacturer-cmd</drivertype>
+      </drivers>
+    </printer>
+
+    <printer>
+      <!-- For all printers which the available driver should take
+           priority over others with 'exact' fit (but not 'exact-cmd') -->
+      <drivers>
+	<drivertype>openprinting-recommended</drivertype>
+	<drivertype>epson-recommended</drivertype>
+	<drivertype>canon-recommended</drivertype>
+      </drivers>
+    </printer>
+
+    <printer>
+      <!-- For all printers (continued) -->
+      <drivers>
 	<drivertype>foomatic-recommended-nonpostscript</drivertype>
 	<drivertype>manufacturer*</drivertype>
 	<drivertype>pdf</drivertype>


### PR DESCRIPTION
Regardless of a good enough driver being available at the time of installing a printer, we always want to query OpenPrinting.org if an Internet available to check if a better one is available, and make sure that such a better driver gets selected when configuring the printer.

The only exception to always querying OpenPrinting.org for a driver is when we either pre-install the same driver in our image (no point in downloading and installing the same one in a different location) or when we already have downloaded it before via eos-config-printer.

https://phabricator.endlessm.com/T10886
